### PR TITLE
Add a default useragent

### DIFF
--- a/src/boilerpipe/extract/__init__.py
+++ b/src/boilerpipe/extract/__init__.py
@@ -28,12 +28,14 @@ class Extractor(object):
     extractor = None
     source    = None
     data      = None
+    headers   = {'User-Agent': 'Mozilla/5.0'}
     
     def __init__(self, extractor='DefaultExtractor', **kwargs):
         if kwargs.get('url'):
-            request   = urllib2.urlopen(kwargs['url'])
-            self.data = request.read()
-            encoding  = request.headers['content-type'].lower().split('charset=')[-1]
+            request     = urllib2.Request(kwargs['url'], headers=self.headers)
+            connection  = urllib2.urlopen(request)
+            self.data   = connection.read()
+            encoding    = connection.headers['content-type'].lower().split('charset=')[-1]
             if encoding.lower() == 'text/html':
                 encoding = chardet.detect(self.data)['encoding']
             self.data = unicode(self.data, encoding)


### PR DESCRIPTION
urllib2 by default does not set a useragent string. On some websites, requests
without a "User-Agent" headers are assumed to be malicious bots and are
therefore blocked.

This adds a "fake" useragent to workaround this.
