### PR TITLE
urllib2 headers changed

### DIFF
--- a/src/boilerpipe/extract/__init__.py
+++ b/src/boilerpipe/extract/__init__.py
@@ -29,7 +29,7 @@ class Extractor(object):
     extractor = None
     source    = None
     data      = None
-    headers   = {'User-Agent': 'Mozilla/5.0'}
+    headers   = {'User-Agent': 'Mozilla'}
     
     def __init__(self, extractor='DefaultExtractor', **kwargs):
         if kwargs.get('url'):


### PR DESCRIPTION
urllib2 headers changed from Mozilla/5.0 to Mozilla  since it was falling for some website give a 406 error

For more check this issue https://github.com/misja/python-boilerpipe/issues/24
