### PR TITLE
fixed getImages RuntimeError when using boilerpipe-1.2.0.jar built…

### DIFF
--- a/src/boilerpipe/extract/__init__.py
+++ b/src/boilerpipe/extract/__init__.py
@@ -74,13 +74,12 @@ class Extractor(object):
             "de.l3s.boilerpipe.sax.ImageExtractor").INSTANCE
         images = extractor.process(self.source, self.data)
         jpype.java.util.Collections.sort(images)
-        images = [
+        return [
             {
-                'src'   : image.getSrc(),
-                'width' : image.getWidth(),
-                'height': image.getHeight(),
-                'alt'   : image.getAlt(),
-                'area'  : image.getArea()
-            } for image in images
+                'src'   : images[i].getSrc(),
+                'width' : images[i].getWidth(),
+                'height': images[i].getHeight(),
+                'alt'   : images[i].getAlt(),
+                'area'  : images[i].getArea()
+            } for i in range(len(images))
         ]
-        return images


### PR DESCRIPTION
…from the latest source

The error that has been fixed was:

    >>> from boilerpipe.extract import Extractor
    >>> extractor = Extractor(extractor='ArticleExtractor', url='some-url')
    >>> extractor.getImages()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "C:\Program Files (x86)\Python 2.7.3\lib\site-packages\boilerpipe\extract\__init__.py", line 84, in getImages
        } for image in images
      File "C:\Program Files (x86)\Python 2.7.3\lib\site-packages\jpype\_jcollection.py", line 32, in __next__
        return next(self.iterator)
    RuntimeError: No matching overloads found. at native\common\jp_method.cpp:121

This occurred when using a version of boilerpipe-1.2.0.jar built from the most recent source.