### PR TITLE
Remove charade in favour of chardet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # python-boilerpipe
 
 
-A python wrapper for [Boilerpipe](http://code.google.com/p/boilerpipe/), an excellent Java library for boilerplate removal and fulltext extraction from HTML pages. 
+A python wrapper for [Boilerpipe](http://code.google.com/p/boilerpipe/), an excellent Java library for boilerplate removal and fulltext extraction from HTML pages.
 
 ## Configuration
 
@@ -9,7 +9,7 @@ A python wrapper for [Boilerpipe](http://code.google.com/p/boilerpipe/), an exce
 Dependencies:
 
  * jpype
- * charade
+ * chardet
 
 The boilerpipe jar files will get fetched and included automatically when building the package.
 
@@ -24,7 +24,7 @@ Fedora
 PIP
 
     sudo pip install JPype
-    sudo pip install charade
+    sudo pip install chardet
     sudo python setup.py install
 
 
@@ -51,7 +51,7 @@ If no extractor is passed the DefaultExtractor will be used by default. Addition
 
 Then, to extract relevant content:
 
-	extracted_text = extractor.getText()
-	
-	extracted_html = extractor.getHTML()
+    extracted_text = extractor.getText()
+
+    extracted_html = extractor.getHTML()
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     },
     install_requires=[
         'JPype1',
-        'charade',
+        'chardet',
     ],
     author='Misja Hoebe',
     author_email='misja.hoebe@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except:
     from urllib.request import urlretrieve
 
-__version__ = '1.2.0.0'
+__version__ = '1.3.0.0'
 boilerpipe_version = '1.2.0'
 DATAPATH = join(abspath(dirname((__file__))), 'src/boilerpipe/data')
 

--- a/src/boilerpipe/extract/__init__.py
+++ b/src/boilerpipe/extract/__init__.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from urllib2 import Request, urlopen
 import socket
-import charade
+import chardet
 import threading
 
 socket.setdefaulttimeout(15)
@@ -40,7 +40,7 @@ class Extractor(object):
             self.data   = connection.read()
             encoding    = connection.headers['content-type'].lower().split('charset=')[-1]
             if encoding.lower() == 'text/html':
-                encoding = charade.detect(self.data)['encoding']
+                encoding = chardet.detect(self.data)['encoding']
             try:
                 self.data = unicode(self.data, encoding)
             except NameError:
@@ -49,10 +49,10 @@ class Extractor(object):
             self.data = kwargs['html']
             try:
                 if not isinstance(self.data, unicode):
-                    self.data = unicode(self.data, charade.detect(self.data)['encoding'])
+                    self.data = unicode(self.data, chardet.detect(self.data)['encoding'])
             except NameError:
                 if not isinstance(self.data, str):
-                    self.data = self.data.decode(charade.detect(self.data)['encoding'])        
+                    self.data = self.data.decode(chardet.detect(self.data)['encoding'])
         else:
             raise Exception('No text or url provided')
 


### PR DESCRIPTION
Charade is not maintained since 2012, it should be removed in favour of chardet. The change is simple as charade and chardet share the same API. I have also bumped the version as it changes the requirements.